### PR TITLE
relax constraits so that it can be used with stack

### DIFF
--- a/arbor-monad-metric.cabal
+++ b/arbor-monad-metric.cabal
@@ -33,11 +33,11 @@ library
   build-depends:
       base              >= 4.7        && < 5
     , containers        >= 0.5.10     && < 0.6
-    , generic-lens      >= 1.1.0      && < 1.2
-    , lens              >= 4.17       && < 4.18
+    , generic-lens      >= 1.0.0.2    && < 1.2
+    , lens              >= 4.16       && < 4.18
     , mtl               >= 2.2.2      && < 2.3
-    , resourcet         >= 1.2.2      && < 1.3
-    , stm               >= 2.5.0      && < 2.6
+    , resourcet         >= 1.2.1      && < 1.3
+    , stm               >= 2.4.0      && < 2.6
     , transformers      >= 0.5.2      && < 0.6
   default-language: Haskell2010
 


### PR DESCRIPTION
lts-12.21 (latest) requires a little wider constraints.