### PR TITLE
Expose non-monadic metric'

### DIFF
--- a/src/Arbor/Monad/Metric/Generic.hs
+++ b/src/Arbor/Monad/Metric/Generic.hs
@@ -3,6 +3,7 @@
 
 module Arbor.Monad.Metric.Generic
   ( metric
+  , metric'
   ) where
 
 import Arbor.Monad.Metric.Type     (MetricFamily (..), Metrics, MonadMetrics)


### PR DESCRIPTION
## Changes
- Expose `metric'` which allows me to use metrics without `MonadMetrics` constraint.